### PR TITLE
Fix async NPE

### DIFF
--- a/core/src/main/scala/org/scalamock/function/FakeFunction.scala
+++ b/core/src/main/scala/org/scalamock/function/FakeFunction.scala
@@ -37,9 +37,14 @@ abstract class FakeFunction(protected val mockContext: MockContext, private[scal
   private def expectationContext = mockContext.expectationContext
 
   def handle(arguments: Product): Any = {
-    val call = new Call(this, arguments)
-    callLog += call
-    expectationContext.handle(call) getOrElse onUnexpected(call)
+    if (Option(callLog).isDefined) {
+      val call = new Call(this, arguments)
+      callLog += call
+      expectationContext.handle(call) getOrElse onUnexpected(call)
+    } else {
+      val msg = "Can't log call to mock object, have expectations been verified already?"
+      throw new RuntimeException(msg)
+    }
   }
   
   protected def onUnexpected(call: Call): Any

--- a/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/PathSpecTest.scala
+++ b/frameworks/scalatest/src/test/scala/org/scalamock/test/scalatest/PathSpecTest.scala
@@ -60,4 +60,14 @@ class PathSpecTest extends path.FunSpec with Matchers with PathMockFactory {
     testFailedException.getMessage() should include("mockFun(bottom-level) once (never called - UNSATISFIED)")
   }
 
+  describe("PathSpec") {
+    val mockFun = mockFunction[String, Unit]
+
+    it("throws an exception with good error message if the mock is called after expectations are verified") {
+      verifyExpectations()
+      val thrown = the [RuntimeException] thrownBy(mockFun("called after verification"))
+      thrown should not be a[NullPointerException]
+      thrown.getMessage should include ("have expectations been verified already?")
+    }
+  }
 }


### PR DESCRIPTION
In several instances during development, we have encountered situations where a NPE is thrown unexpectedly and without explanation. After some investigation it seems that it's happening when a mock is called after expectations have already been verified.

This can happen easily when using ScalaTest's `PathSpec` variants to test async code. The developer forgets to wait for their async call to complete, proceeds to call `verifyExpectations`, and only after the verification is the mock function invoked (at which point the mock's call log has been nullified by https://github.com/PagerDuty/ScalaMock/blob/master/core/src/main/scala/org/scalamock/MockFactoryBase.scala#L84).

This PR avoids the NPE by throwing a more appropriate exception if the `callLog` has been set to `null`.