### PR TITLE
Enable mocking a trait which has a final method.

### DIFF
--- a/core/src/main/scala/org/scalamock/clazz/MockMaker.scala
+++ b/core/src/main/scala/org/scalamock/clazz/MockMaker.scala
@@ -305,6 +305,7 @@ class MockMaker[C <: Context](val ctx: C) {
     val typeToMock = weakTypeOf[T]
     val anon = TypeName("$anon")
     val methodsToMock = methodsNotInObject.filter { m =>
+      !m.isFinal &&
       !m.isConstructor && !m.isPrivate && m.privateWithin == NoSymbol &&
         !m.asInstanceOf[reflect.internal.HasFlags].hasFlag(reflect.internal.Flags.BRIDGE) &&
         !m.isParamWithDefault && // see issue #43

--- a/core_tests/src/main/scala/com/paulbutcher/test/FinalMethodTrait.scala
+++ b/core_tests/src/main/scala/com/paulbutcher/test/FinalMethodTrait.scala
@@ -1,0 +1,7 @@
+package com.paulbutcher.test
+
+trait FinalMethodTrait {
+  def someMethod: Int
+
+  final def someFinalMethod: Int = 1
+}

--- a/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
+++ b/core_tests/src/test/scala/com/paulbutcher/test/mock/MockTest.scala
@@ -403,5 +403,18 @@ class MockTest extends FreeSpec with MockFactory with ShouldMatchers {
 
       val m = mock[TestNonEmptyDefaultConstructor]
     }
+
+    "stub/mock a non-final method on a trait which has a (different) final method" in withExpectations {
+      val m = stub[FinalMethodTrait]
+      val expectedInt = 3
+      (m.someMethod _).when().returns(expectedInt)
+      m.someMethod should equal(expectedInt)
+    }
+
+    "not stub/mock a final method on a trait" in withExpectations {
+      val m = stub[FinalMethodTrait]
+      // it would be nice to make this a compile error, but... macro-fu not strong enough
+      a[NoSuchMethodException] should be thrownBy((m.someFinalMethod _).when().returns(3))
+    }
   }
 }


### PR DESCRIPTION
Merging in https://github.com/paulbutcher/ScalaMock/pull/132 with a few test modifications.