### PR TITLE
Changes for publishing 3.3.0 to PD bintray.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
-# ScalaMock [![Build Status](https://travis-ci.org/paulbutcher/ScalaMock.svg?branch=master)](https://travis-ci.org/paulbutcher/ScalaMock)
+# ScalaMock
+
+## Note
+
+This project is hopefully a temporary fork of the excellent https://github.com/paulbutcher/ScalaMock.
+
+While `scala.meta` is still elusive, and more systemic solutions to some of ScalaMock's quirks are out of reach, 
+we aim to publish a ScalaMock that fixes or works around some of the more annoying issues.
+
+This library is published to PagerDuty Bintray OSS Maven repository:
+```scala
+resolvers += "bintray-pagerduty-oss-maven" at "https://dl.bintray.com/pagerduty/oss-maven"
+```
+
+Adding the dependency to your SBT build file:
+```scala
+libraryDependencies += "com.pagerduty" %% "scalamock-scalatest-support" % "3.2.2" % "test"
+```
 
 Native Scala mocking.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## New in (com.pagerduty) ScalaMock 3.3.0
+
+- [new feature] support for mocking non-final methods in traits with final methods
+- [new feature, 2.11 only] support for mocking classes with non-empty default constructor
+- [fix] better error message when invoking a mock after verification has been completed
+
 ## New in ScalaMock 3.2.1
 
 - [new feature] support for custom parameter matchers (issue #42)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,13 +21,18 @@
 import sbt._
 import Keys._
 import sbt.inc.Analysis
+import bintray.BintrayKeys._
 
 object BuildSettings {
-  val buildVersion = "3.2.2"
+  val buildVersion = "3.3.0"
   val buildScalaVersion = "2.11.5"
 
   val buildSettings = Defaults.coreDefaultSettings ++ Seq(
-    organization := "org.scalamock",
+    bintrayOrganization := Some("pagerduty"),
+    bintrayRepository := "oss-maven",
+    licenses += ("BSD Simplified", url("https://opensource.org/licenses/bsd-license.php")),
+    publishMavenStyle := true,
+    organization := "com.pagerduty",
     version := buildVersion,
     scalaVersion := buildScalaVersion,
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature"),
@@ -35,14 +40,6 @@ object BuildSettings {
     resolvers += Resolver.sonatypeRepo("releases"),
     resolvers += Resolver.sonatypeRepo("snapshots"),
     resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
-
-    publishTo <<= version { v =>
-      val nexus = "https://oss.sonatype.org/"
-      if (v.trim.endsWith("SNAPSHOT"))
-        Some("snapshots" at nexus + "content/repositories/snapshots") 
-      else
-        Some("releases" at nexus + "service/local/staging/deploy/maven2")
-    },
     pomIncludeRepository := { _ => false },
     publishArtifact in Test := false,
     pomExtra := (
@@ -55,14 +52,19 @@ object BuildSettings {
         </license>
       </licenses>
       <scm>
-        <url>git@github.com:paulbutcher/ScalaMock.git</url>
-        <connection>scm:git:git@github.com:paulbutcher/ScalaMock.git</connection>
+        <url>git@github.com:PagerDuty/ScalaMock.git</url>
+        <connection>scm:git:git@github.com:PagerDuty/ScalaMock.git</connection>
       </scm>
       <developers>
         <developer>
           <id>paulbutcher</id>
           <name>Paul Butcher</name>
           <url>http://paulbutcher.com/</url>
+        </developer>
+        <developer>
+          <id>pagerduty-core</id>
+          <name>PagerDuty Core Team</name>
+          <url>http://pagerduty.com/</url>
         </developer>
       </developers>),
   

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,7 @@ addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.4.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.7")
+
+resolvers += Resolver.jcenterRepo
+
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
This PR allows us to publish PD's ScalaMock fork to our Bintray artifact repository.